### PR TITLE
docs: fix no parameter connect string example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For more information you can read [the PgJDBC driver documentation](https://jdbc
 The driver recognises JDBC URLs of the form:
 ```
 jdbc:postgresql:database
-jdbc:postgresql:/
+jdbc:postgresql:
 jdbc:postgresql://host/database
 jdbc:postgresql://host/
 jdbc:postgresql://host:port/database


### PR DESCRIPTION
postgresql-42.1.4 - DriverManager.getConnection("jdbc:postgresql:/") throws org.postgresql.util.PSQLException: FATAL: database "/" does not exist. The trailing slash is being interpreted as the database name. DriverManager.getConnection("jdbc:postgresql:") connects to the default port on localhost using the user's name as the database.