### PR TITLE
docs: fix the URL regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ jdbc:postgresql://host:port/
 ```
 The general format for a JDBC URL for connecting to a PostgreSQL server is as follows, with items in square brackets ([ ]) being optional:
 ```
-jdbc:postgresql://[host][:port][/[database]][?property1=value1[&property2=value2]...]
+jdbc:postgresql:[//host[:port]/][database][?property1=value1[&property2=value2]...]
 ```
 where:
  * **jdbc:postgresql:** (Required) is known as the sub-protocol and is constant.


### PR DESCRIPTION
The "//[host][:port][/database]" portion of the URL regex does not accurately represent the URL variations that are actually accepted.
The proposed "[//host[:port]/][database]" does.